### PR TITLE
Add persistent high score list

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,25 +197,41 @@
 
   function loadScores() {
     try {
-    const data = JSON.parse(localStorage.getItem('flappyDronehighScores') || '[]');
+      const data = JSON.parse(localStorage.getItem('flappyDronehighScores') || '[]');
       if (!Array.isArray(data)) return [];
       return data
-        .map(item =>
-          typeof item === 'number'
-            ? item
-            : typeof item === 'object' && item !== null
-              ? Number(item.score)
-              : Number(item)
-        )
-        .filter(n => !isNaN(n));
+        .map(item => {
+          if (typeof item === 'number') {
+            return { name: 'FlappyDrone', score: item };
+          }
+          if (typeof item === 'object' && item !== null) {
+            const s = Number(item.score);
+            if (isNaN(s)) return null;
+            return { name: String(item.name || 'FlappyDrone'), score: s };
+          }
+          const s = Number(item);
+          return isNaN(s) ? null : { name: 'FlappyDrone', score: s };
+        })
+        .filter(Boolean)
+        .sort((a, b) => b.score - a.score)
+        .slice(0, 5);
     } catch (e) {
       return [];
     }
   }
 
-  function saveScore(newScore) {
-    highScores.push(Number(newScore) || 0);
-    highScores.sort((a, b) => b - a);
+  function recordHighScore(newScore) {
+    const scoreNum = Number(newScore) || 0;
+    const qualifies =
+      highScores.length < 5 || scoreNum > highScores[highScores.length - 1].score;
+    if (!qualifies) return;
+    let name = 'FlappyDrone';
+    if (typeof prompt === 'function') {
+      const entered = prompt('New High Score! Enter your name:', 'FlappyDrone');
+      if (entered !== null && entered.trim()) name = entered.trim();
+    }
+    highScores.push({ name, score: scoreNum });
+    highScores.sort((a, b) => b.score - a.score);
     highScores = highScores.slice(0, 5);
     try {
       localStorage.setItem('flappyDronehighScores', JSON.stringify(highScores));
@@ -253,14 +269,16 @@
     ctx.fillText('Tap to Restart', canvas.width/2, canvas.height/2 - 5);
     ctx.font = 'bold 20px sans-serif';
     ctx.fillText('High Scores', canvas.width/2, canvas.height/2 + 30);
-    highScores.forEach((s, i) => {
-      ctx.fillText(`${i + 1}. ${s}`, canvas.width/2, canvas.height/2 + 60 + i * 22);
+    highScores.forEach((entry, i) => {
+      ctx.fillText(`${i + 1}. ${entry.name} - ${entry.score}`,
+                  canvas.width/2,
+                  canvas.height/2 + 60 + i * 22);
     });
   }
 
   function reset() {
     playDeathSound();
-    saveScore(score);
+    recordHighScore(score);
     state = 'dead';
     frame = 0;
     frameTime = 0;

--- a/index.html
+++ b/index.html
@@ -195,6 +195,26 @@
   let frameTime = 0;
   let lastTapTime = 0;
 
+  function loadScores() {
+    try {
+      const data = JSON.parse(localStorage.getItem('highScores') || '[]');
+      return Array.isArray(data) ? data : [];
+    } catch (e) {
+      return [];
+    }
+  }
+
+  function saveScore(newScore) {
+    highScores.push(newScore);
+    highScores.sort((a, b) => b - a);
+    highScores = highScores.slice(0, 5);
+    try {
+      localStorage.setItem('highScores', JSON.stringify(highScores));
+    } catch (e) {}
+  }
+
+  let highScores = loadScores();
+
   let startedOnce = false;
 
   function start() {
@@ -219,13 +239,19 @@
     ctx.fillStyle = '#000';
     ctx.textAlign = 'center';
     ctx.font = 'bold 32px sans-serif';
-    ctx.fillText('Game Over', canvas.width/2, canvas.height/2 - 20);
+    ctx.fillText('Game Over', canvas.width/2, canvas.height/2 - 40);
     ctx.font = 'bold 24px sans-serif';
-    ctx.fillText('Tap to Restart', canvas.width/2, canvas.height/2 + 20);
+    ctx.fillText('Tap to Restart', canvas.width/2, canvas.height/2 - 5);
+    ctx.font = 'bold 20px sans-serif';
+    ctx.fillText('High Scores', canvas.width/2, canvas.height/2 + 30);
+    highScores.forEach((s, i) => {
+      ctx.fillText(`${i + 1}. ${s}`, canvas.width/2, canvas.height/2 + 60 + i * 22);
+    });
   }
 
   function reset() {
     playDeathSound();
+    saveScore(score);
     state = 'dead';
     frame = 0;
     frameTime = 0;

--- a/index.html
+++ b/index.html
@@ -197,7 +197,7 @@
 
   function loadScores() {
     try {
-      const data = JSON.parse(localStorage.getItem('highScores') || '[]');
+    const data = JSON.parse(localStorage.getItem('flappyDronehighScores') || '[]');
       if (!Array.isArray(data)) return [];
       return data
         .map(item =>
@@ -218,7 +218,7 @@
     highScores.sort((a, b) => b - a);
     highScores = highScores.slice(0, 5);
     try {
-      localStorage.setItem('highScores', JSON.stringify(highScores));
+      localStorage.setItem('flappyDronehighScores', JSON.stringify(highScores));
     } catch (e) {}
   }
 

--- a/index.html
+++ b/index.html
@@ -198,14 +198,23 @@
   function loadScores() {
     try {
       const data = JSON.parse(localStorage.getItem('highScores') || '[]');
-      return Array.isArray(data) ? data : [];
+      if (!Array.isArray(data)) return [];
+      return data
+        .map(item =>
+          typeof item === 'number'
+            ? item
+            : typeof item === 'object' && item !== null
+              ? Number(item.score)
+              : Number(item)
+        )
+        .filter(n => !isNaN(n));
     } catch (e) {
       return [];
     }
   }
 
   function saveScore(newScore) {
-    highScores.push(newScore);
+    highScores.push(Number(newScore) || 0);
     highScores.sort((a, b) => b - a);
     highScores = highScores.slice(0, 5);
     try {


### PR DESCRIPTION
## Summary
- keep a localStorage-backed list of high scores
- show the top 5 scores on the game over screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686efdc94c288323ae4ad71d33e3d1c8