### PR TITLE
Add clouds background to Flappy Drone

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,22 @@
   const canvas = document.getElementById('gameCanvas');
   const ctx = canvas.getContext('2d');
 
+  const CLOUD_COUNT = 8;
+  let clouds = [];
+  function initClouds() {
+    clouds = [];
+    for (let i = 0; i < CLOUD_COUNT; i++) {
+      const scale = 0.5 + Math.random() * 0.5;
+      clouds.push({
+        x: Math.random() * canvas.width,
+        y: Math.random() * canvas.height * 0.5,
+        width: 60 * scale,
+        height: 40 * scale,
+        speed: 0.02 + Math.random() * 0.05
+      });
+    }
+  }
+
   function resize() {
     canvas.width = window.innerWidth;
     canvas.height = window.innerHeight;
@@ -61,22 +77,6 @@
   const PIPE_WIDTH = 60;
   const PIPE_INTERVAL = 1600; // ms
   const PIPE_SPEED = 0.2; // px per ms
-
-  const CLOUD_COUNT = 8;
-  let clouds = [];
-  function initClouds() {
-    clouds = [];
-    for (let i = 0; i < CLOUD_COUNT; i++) {
-      const scale = 0.5 + Math.random() * 0.5;
-      clouds.push({
-        x: Math.random() * canvas.width,
-        y: Math.random() * canvas.height * 0.5,
-        width: 60 * scale,
-        height: 40 * scale,
-        speed: 0.02 + Math.random() * 0.05
-      });
-    }
-  }
 
   // --- Audio Setup ---
   const AudioContext = window.AudioContext || window.webkitAudioContext;

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
   function resize() {
     canvas.width = window.innerWidth;
     canvas.height = window.innerHeight;
+    initClouds();
   }
   window.addEventListener('resize', resize);
   resize();
@@ -60,6 +61,22 @@
   const PIPE_WIDTH = 60;
   const PIPE_INTERVAL = 1600; // ms
   const PIPE_SPEED = 0.2; // px per ms
+
+  const CLOUD_COUNT = 8;
+  let clouds = [];
+  function initClouds() {
+    clouds = [];
+    for (let i = 0; i < CLOUD_COUNT; i++) {
+      const scale = 0.5 + Math.random() * 0.5;
+      clouds.push({
+        x: Math.random() * canvas.width,
+        y: Math.random() * canvas.height * 0.5,
+        width: 60 * scale,
+        height: 40 * scale,
+        speed: 0.02 + Math.random() * 0.05
+      });
+    }
+  }
 
   // --- Audio Setup ---
   const AudioContext = window.AudioContext || window.webkitAudioContext;
@@ -346,6 +363,13 @@
   populatePipes();
 
   function update(delta) {
+    clouds.forEach(c => {
+      c.x -= c.speed * delta;
+      if (c.x + c.width < 0) {
+        c.x = canvas.width;
+        c.y = Math.random() * canvas.height * 0.5;
+      }
+    });
     if (state === 'intro') return;
 
     if (state === 'playing') {
@@ -395,6 +419,13 @@
 
   function draw() {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
+    // Draw clouds
+    ctx.fillStyle = 'rgba(255,255,255,0.8)';
+    clouds.forEach(c => {
+      ctx.beginPath();
+      ctx.ellipse(c.x, c.y, c.width / 2, c.height / 2, 0, 0, Math.PI * 2);
+      ctx.fill();
+    });
     // Draw drone
     if (droneImg.complete) {
       const row = state === 'dead' ? 1 : 0;


### PR DESCRIPTION
## Summary
- animate simple clouds in the background
- move clouds over time and redraw each frame

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686fcd499a408323a5e1756ebf815ca2