### PR TITLE
Fix FPS counter fluctuations

### DIFF
--- a/index.html
+++ b/index.html
@@ -473,6 +473,8 @@
 
     const delta = now - last;
     if (delta < FRAME_MIN) {
+      // Update timestamp even when skipping to keep FPS stable
+      last = now;
       window.requestAnimationFrame(loop);
       return;
     }


### PR DESCRIPTION
## Summary
- keep timestamp updated in skipped frames to maintain a stable FPS reading

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870b99928d08323bbffe449c5cef4fb